### PR TITLE
Fix the issue

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -455,7 +455,7 @@ def init_instrumentations(
         elif instrument == Instruments.COHERE:
             if init_cohere_instrumentor():
                 instrument_set = True
-        elif instrument == Instruments.CREWAI:
+        elif instrument == Instruments.CREWAI or instrument == Instruments.CREW:
             if init_crewai_instrumentor():
                 instrument_set = True
         elif instrument == Instruments.GOOGLE_GENERATIVEAI:


### PR DESCRIPTION
```
fix(crewai): Ensure backward compatibility for deprecated CREW instrument alias

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `fix(crewai): Ensure backward compatibility for deprecated CREW instrument alias`.
- [ ] (If applicable) I have updated the documentation accordingly.

This PR fixes an issue where the `CrewAI` instrumentation would not initialize correctly if the deprecated `Instruments.CREW` alias was used.

Previously, after the `CrewAI` instrumentation name was updated, the initialization logic in `tracing.py` only checked for `Instruments.CREWAI`. This meant that users still relying on the `Instruments.CREW` alias would experience silent failures in their instrumentation setup.

This change modifies the `init_instrumentations` function to explicitly check for both `Instruments.CREWAI` and `Instruments.CREW`, ensuring that the deprecated alias continues to function as expected for backward compatibility.
```

---
[Slack Thread](https://extremevibecoders.slack.com/archives/C09EUN3EYMP/p1757525222676479?thread_ts=1757525222.676479&cid=C09EUN3EYMP)

<a href="https://cursor.com/background-agent?bcId=bc-30aa8815-9ba3-43ee-89e0-f7ca236cadac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30aa8815-9ba3-43ee-89e0-f7ca236cadac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

