### PR TITLE
Fix anthropic instrumentation get_final_message error

### DIFF
--- a/FIX_SUMMARY.md
+++ b/FIX_SUMMARY.md
@@ -1,0 +1,58 @@
+# Fix for get_final_message AttributeError in opentelemetry-instrumentation-anthropic
+
+## Problem
+The current implementation (v0.46.2) of `opentelemetry-instrumentation-anthropic` wraps streaming responses from the Anthropic SDK with plain async generators that don't preserve the original methods from the stream objects. This causes an `AttributeError: 'async_generator' object has no attribute 'get_final_message'` when trying to access the `get_final_message` method that is available on the original Anthropic SDK stream objects.
+
+## Root Cause
+The issue occurs in two places:
+
+1. **Direct streaming responses**: When `is_streaming_response(response)` returns `True`, the code calls `abuild_from_streaming_response()` which returns a plain `async_generator` that only yields events but doesn't expose the original stream's methods.
+
+2. **Stream managers**: Similar issue with `WrappedAsyncMessageStreamManager` which also returns plain generators.
+
+## Solution
+Created wrapper classes that preserve all original methods while maintaining instrumentation functionality:
+
+### 1. WrappedAsyncStream
+- Wraps the original `AsyncStream` object
+- Uses `__getattr__` delegation to preserve all original methods (including `get_final_message`)
+- Implements `__aiter__` and `__anext__` to provide instrumented iteration
+- Maintains full compatibility with the original stream API
+
+### 2. WrappedStream  
+- Similar wrapper for synchronous `Stream` objects
+- Uses `__getattr__` delegation for method preservation
+- Implements `__iter__` and `__next__` for instrumented iteration
+
+### 3. Updated WrappedAsyncMessageStreamManager
+- Now returns `WrappedAsyncStream` instead of plain generators
+- Preserves all original functionality while adding instrumentation
+
+## Files Modified
+
+### `/workspace/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py`
+- Added `WrappedAsyncStream` class
+- Added `WrappedStream` class  
+- Updated `WrappedAsyncMessageStreamManager` to use new wrapper
+- Updated `WrappedMessageStreamManager` to use new wrapper
+
+### `/workspace/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py`
+- Updated async streaming response handler to use `WrappedAsyncStream`
+- Updated sync streaming response handler to use `WrappedStream`
+
+## Key Features of the Fix
+
+1. **Full Method Preservation**: All methods from the original stream objects are preserved via `__getattr__` delegation
+2. **Instrumentation Maintained**: All existing telemetry, metrics, and tracing functionality is preserved
+3. **Backward Compatibility**: Existing code continues to work without changes
+4. **Performance**: Minimal overhead - delegation only happens for method access, not iteration
+
+## Testing
+The fix has been tested with mock objects to verify:
+- `get_final_message` method is accessible on wrapped streams
+- Other methods are also preserved
+- Streaming iteration continues to work
+- Instrumentation functionality is maintained
+
+## Impact
+This fix resolves the `AttributeError` while maintaining full backward compatibility and all existing instrumentation features. Users can now access `get_final_message` and any other methods available on the original Anthropic SDK stream objects.

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
@@ -558,9 +558,11 @@ def _wrap(
     end_time = time.time()
 
     if is_streaming_response(response):
-        return build_from_streaming_response(
-            span,
+        from opentelemetry.instrumentation.anthropic.streaming import WrappedStream
+        
+        return WrappedStream(
             response,
+            span,
             instance._client,
             start_time,
             token_histogram,
@@ -679,9 +681,11 @@ async def _awrap(
         raise e
 
     if is_streaming_response(response):
-        return abuild_from_streaming_response(
-            span,
+        from opentelemetry.instrumentation.anthropic.streaming import WrappedAsyncStream
+        
+        return WrappedAsyncStream(
             response,
+            span,
             instance._client,
             start_time,
             token_histogram,

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
@@ -298,6 +298,73 @@ async def abuild_from_streaming_response(
         span.end()
 
 
+class WrappedStream:
+    """Wrapper for Stream that preserves original methods while adding instrumentation"""
+
+    def __init__(
+        self,
+        original_stream,
+        span,
+        instance,
+        start_time,
+        token_histogram,
+        choice_counter,
+        duration_histogram,
+        exception_counter,
+        event_logger,
+        kwargs,
+    ):
+        self._original_stream = original_stream
+        self._span = span
+        self._instance = instance
+        self._start_time = start_time
+        self._token_histogram = token_histogram
+        self._choice_counter = choice_counter
+        self._duration_histogram = duration_histogram
+        self._exception_counter = exception_counter
+        self._event_logger = event_logger
+        self._kwargs = kwargs
+        self._instrumented_generator = None
+
+    def __getattr__(self, name):
+        """Delegate attribute access to the original stream"""
+        return getattr(self._original_stream, name)
+
+    def __iter__(self):
+        """Return the instrumented iterator"""
+        if self._instrumented_generator is None:
+            self._instrumented_generator = build_from_streaming_response(
+                self._span,
+                self._original_stream,
+                self._instance,
+                self._start_time,
+                self._token_histogram,
+                self._choice_counter,
+                self._duration_histogram,
+                self._exception_counter,
+                self._event_logger,
+                self._kwargs,
+            )
+        return self._instrumented_generator
+
+    def __next__(self):
+        """Return the next item from the instrumented generator"""
+        if self._instrumented_generator is None:
+            self._instrumented_generator = build_from_streaming_response(
+                self._span,
+                self._original_stream,
+                self._instance,
+                self._start_time,
+                self._token_histogram,
+                self._choice_counter,
+                self._duration_histogram,
+                self._exception_counter,
+                self._event_logger,
+                self._kwargs,
+            )
+        return next(self._instrumented_generator)
+
+
 class WrappedMessageStreamManager:
     """Wrapper for MessageStreamManager that handles instrumentation"""
 
@@ -328,10 +395,10 @@ class WrappedMessageStreamManager:
     def __enter__(self):
         # Call the original stream manager's __enter__ to get the actual stream
         stream = self._stream_manager.__enter__()
-        # Return the wrapped stream
-        return build_from_streaming_response(
-            self._span,
+        # Return the wrapped stream that preserves original methods
+        return WrappedStream(
             stream,
+            self._span,
             self._instance,
             self._start_time,
             self._token_histogram,
@@ -344,6 +411,73 @@ class WrappedMessageStreamManager:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         return self._stream_manager.__exit__(exc_type, exc_val, exc_tb)
+
+
+class WrappedAsyncStream:
+    """Wrapper for AsyncStream that preserves original methods while adding instrumentation"""
+
+    def __init__(
+        self,
+        original_stream,
+        span,
+        instance,
+        start_time,
+        token_histogram,
+        choice_counter,
+        duration_histogram,
+        exception_counter,
+        event_logger,
+        kwargs,
+    ):
+        self._original_stream = original_stream
+        self._span = span
+        self._instance = instance
+        self._start_time = start_time
+        self._token_histogram = token_histogram
+        self._choice_counter = choice_counter
+        self._duration_histogram = duration_histogram
+        self._exception_counter = exception_counter
+        self._event_logger = event_logger
+        self._kwargs = kwargs
+        self._instrumented_generator = None
+
+    def __getattr__(self, name):
+        """Delegate attribute access to the original stream"""
+        return getattr(self._original_stream, name)
+
+    def __aiter__(self):
+        """Return the instrumented async iterator"""
+        if self._instrumented_generator is None:
+            self._instrumented_generator = abuild_from_streaming_response(
+                self._span,
+                self._original_stream,
+                self._instance,
+                self._start_time,
+                self._token_histogram,
+                self._choice_counter,
+                self._duration_histogram,
+                self._exception_counter,
+                self._event_logger,
+                self._kwargs,
+            )
+        return self._instrumented_generator
+
+    async def __anext__(self):
+        """Return the next item from the instrumented generator"""
+        if self._instrumented_generator is None:
+            self._instrumented_generator = abuild_from_streaming_response(
+                self._span,
+                self._original_stream,
+                self._instance,
+                self._start_time,
+                self._token_histogram,
+                self._choice_counter,
+                self._duration_histogram,
+                self._exception_counter,
+                self._event_logger,
+                self._kwargs,
+            )
+        return await self._instrumented_generator.__anext__()
 
 
 class WrappedAsyncMessageStreamManager:
@@ -376,10 +510,10 @@ class WrappedAsyncMessageStreamManager:
     async def __aenter__(self):
         # Call the original stream manager's __aenter__ to get the actual stream
         stream = await self._stream_manager.__aenter__()
-        # Return the wrapped stream
-        return abuild_from_streaming_response(
-            self._span,
+        # Return the wrapped stream that preserves original methods
+        return WrappedAsyncStream(
             stream,
+            self._span,
             self._instance,
             self._start_time,
             self._token_histogram,


### PR DESCRIPTION
```
fix(anthropic): Preserve Anthropic SDK stream methods on instrumented responses

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

### Problem

The `opentelemetry-instrumentation-anthropic` was previously wrapping Anthropic SDK streaming responses (both synchronous and asynchronous) with plain generators. This caused an `AttributeError` when attempting to access methods like `get_final_message` that are available on the original `anthropic.Stream` and `anthropic.AsyncStream` objects.

### Solution

Introduced `WrappedStream` and `WrappedAsyncStream` classes. These wrappers:
- Delegate attribute access to the original Anthropic stream object using `__getattr__`, ensuring all original methods (e.g., `get_final_message`) are preserved.
- Internally use the existing instrumentation logic (`build_from_streaming_response` and `abuild_from_streaming_response`) for iteration, maintaining full observability.

The instrumentation now returns instances of these wrapper classes for streaming responses, allowing users to access all expected stream methods while still benefiting from OpenTelemetry instrumentation.

### Why this change?

This change ensures full compatibility with the Anthropic SDK's streaming API, specifically addressing the `AttributeError` when `get_final_message` or other stream-specific methods are called on an instrumented response. It provides a more robust and complete instrumentation experience without altering the expected behavior of the underlying SDK.
```

---
[Slack Thread](https://augmenttestinstance.slack.com/archives/C09DJKHS268/p1757539524278569?thread_ts=1757539524.278569&cid=C09DJKHS268)

<a href="https://cursor.com/background-agent?bcId=bc-aa7da663-6eef-403e-9e08-988ae344412f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa7da663-6eef-403e-9e08-988ae344412f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

